### PR TITLE
Update rollup version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.0.0",
         "@rollup/plugin-node-resolve": "^11.0.0",
-        "rollup": "^2.3.4",
+        "rollup": "^2.79.1",
         "rollup-plugin-css-only": "^3.1.0",
         "rollup-plugin-livereload": "^2.0.0",
         "rollup-plugin-svelte": "^7.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
-    "rollup": "^2.3.4",
+    "rollup": "^2.79.1",
     "rollup-plugin-css-only": "^3.1.0",
     "rollup-plugin-livereload": "^2.0.0",
     "rollup-plugin-svelte": "^7.0.0",


### PR DESCRIPTION
Actually, this is just for testing purposes.

As I ran `npm run dev` in the front end directory it updated the version of rollup so might consider reinstalling it or are there any reasons to use the older version that was specified?

And I accidentally created a pull request for this branch into main. Pls ignore, I somehow was blind af.

Sorry for my bad English :(