### PR TITLE
fixing the links of the docs front pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,13 +13,13 @@ Kev.in is a learning platform for programming beginners. It is released under th
 
 The source code of Kev.in can be downloaded at:
 
-[GitHub](https://github.com/mlinke-ai/kev.in)
+[GitHub](https://github.com/mlinke-ai/kev_in)
 
 The documentation can be found online at:
 
-[GitHub Pages](https://mlinke.github.io/kev.in)
+[GitHub Pages](https://mlinke-ai.github.io/kev_in/)
 
-Bug reports should be done through the [Issue Tracker](https://github.com/mlinke-ai/kev.in/issues) of Kev.in on GitHub.
+Bug reports should be done through the [Issue Tracker](https://github.com/mlinke-ai/kev_in/issues) of Kev.in on GitHub.
 
 # Testing
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,7 @@ Basically Kev.in can run on any system. It relies mostly on Python, some Python 
 The source code of Kev.in can be downloaded from GitHub:
 
 ```
-git clone https://github.com/mlinke-ai/kev.in.git
+git clone https://github.com/mlinke-ai/kev_in.git
 ```
 
 # Installation


### PR DESCRIPTION
Fixed the links from the documentation front pages as repo was renamed from kev.in to kev_in