### PR TITLE
Dev refactor login

### DIFF
--- a/backend/lib/routes/user.py
+++ b/backend/lib/routes/user.py
@@ -64,12 +64,7 @@ class UserResource(Resource):
 
             user_obj = UserModel.query.filter_by(user_id=id).one()
 
-            result = dict(
-                user_id=int(user_obj.user_id),
-                user_name=str(user_obj.user_name),
-                user_mail=str(user_obj.user_mail),
-                user_role=user_obj.user_role.name,
-            )
+            result = user_obj.to_json()
             return utils.makeResponseNewCookie(result, 200, request.cookies)
 
         args = parser.parse_args()

--- a/docs/api/login.md
+++ b/docs/api/login.md
@@ -59,7 +59,12 @@ Arguments are constructed as dictionaries or JSON objects.
 
     ```JSON
     {
-        "message": "Welcome John Doe!"
+        "message": "Welcome John Doe!",
+        "user_id": 3,
+        "user_mail": "johnDoe@example.com",
+        "user_name": "John Doe",
+        "user_role_name": "User",
+        "user_role_value": 3
     }
     ```
 

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -103,7 +103,8 @@ NOTE: It is possible that the system returns up to `Config.MAX_ITEMS_RETURNED` i
 		"user_id": 1,
 		"user_name": "John Doe",
 		"user_mail": "john.doe@example.com",
-		"user_role": "User"
+		"user_role_name": "User",
+        "user_role_value": 3
 	}
 	```
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -46,7 +46,17 @@ class LoginTest(unittest.TestCase):
         )
 
         self.assertIn("Set-Cookie", r.headers)  # cookie with JWT should be returned
-        self.assertDictEqual({"message": f"Welcome {LoginTest.user_name}!"}, r.json())
+        self.assertDictEqual(
+            {
+                "message": f"Welcome {LoginTest.user_name}!",
+                "user_id": 1,
+                "user_mail": "sadmin@example.com",
+                "user_name": "sadmin",
+                "user_role_name": "SAdmin",
+                "user_role_value": 1
+            },
+            r.json()
+            )
         self.assertEqual(200, r.status_code)
 
     def test_login_fail(self) -> None:


### PR DESCRIPTION
# Fixing issue #162
- the login route now returns user data on successful login (see docs)

## minor change in user GET
- chaged to the new reponse format when sending an empty GET request (attribute `user_role` is splitted into `user_role_name` and `user_role_value`)
- please take this into cosideration on the frontend side