### PR TITLE
Allowed multiple IDs in GET request

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: python-no-eval
       - id: python-use-type-annotations
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [-l 120]

--- a/backend/lib/routes/exercise.py
+++ b/backend/lib/routes/exercise.py
@@ -25,7 +25,7 @@ class ExerciseResource(Resource):
         """
         # create a parser for the request data and parse the request
         parser = reqparse.RequestParser()
-        parser.add_argument("exercise_id", type=int, help="{error_msg}", location="args")
+        parser.add_argument("exercise_id", type=int, help="{error_msg}", action="append", location="args")
         parser.add_argument("exercise_title", type=str, help="{error_msg}", location="args")
         parser.add_argument("exercise_description", type=str, help="{error_msg}", location="args")
         parser.add_argument(
@@ -69,7 +69,7 @@ class ExerciseResource(Resource):
 
         query = db_engine.select(ExerciseModel).order_by(ExerciseModel.exercise_id)
         if args["exercise_id"]:
-            query = query.where(ExerciseModel.exercise_id == args["exercise_id"])
+            query = query.filter(ExerciseModel.exercise_id.in_(args["exercise_id"]))
         if args["exercise_title"]:
             query = query.where(ExerciseModel.exercise_title == args["exercise_title"])
         if args["exercise_description"]:

--- a/backend/lib/routes/user.py
+++ b/backend/lib/routes/user.py
@@ -37,7 +37,7 @@ class UserResource(Resource):
         """
         # create a parser for the request data and parse the request
         parser = reqparse.RequestParser()
-        parser.add_argument("user_id", type=int, default=0, help="{error_msg}", location="args")
+        parser.add_argument("user_id", type=int, default=0, help="{error_msg}", action="append", location="args")
         parser.add_argument("user_name", type=str, default="", help="{error_msg}", location="args")
         parser.add_argument("user_mail", type=str, default="", help="{error_msg}", location="args")
         parser.add_argument(
@@ -71,7 +71,7 @@ class UserResource(Resource):
 
         query = db_engine.select(UserModel).order_by(UserModel.user_id)
         if args["user_id"]:
-            query = query.where(UserModel.user_id == args["user_id"])
+            query = query.filter(UserModel.user_id.in_(args["user_id"]))
         if args["user_name"]:
             query = query.where(UserModel.user_name == args["user_name"])
         if args["user_mail"]:

--- a/docs/api/exercise.md
+++ b/docs/api/exercise.md
@@ -46,7 +46,7 @@ Replace `<URLarguments>` with key value pairs in the form `key=value`(key is the
 
 | Argument | Type | Necessity | Example | Description |
 |---|---|---|---|---|
-| `exercise_id` | `int` | optional | `1` | The ID of the exercise. Normally obtained after creating a new exercise. |
+| `exercise_id` | `int` | optional | `1` | The ID of the exercise. Normally obtained after creating a new exercise. This argument can be provided multiple times to select multiple exercises. All other arguments still apply.|
 | `exercise_title` | `string` | optional | `My Exercise` | The display title of the exercise. |
 | `exercise_description` | `string` | optional | `This is a good Test example!` | The description of the exercise
 | `exercise_type` | `int` | optional | `2` | The type of the exercise: `1` for GapTextExercise, `2` for SyntaxExercise, `3` for ParsonsPuzzleExercise, `4` for FindTheBugExercise, `5` for DocumentationExercise, `6` for OutputExercise, `7` for ProgrammingExercise|

--- a/docs/api/solution.md
+++ b/docs/api/solution.md
@@ -44,7 +44,7 @@ Replace `<URLarguments>` with key value pairs in the form `key=value`(key is the
 
 | Argument | Type | Necessity | Example | Description |
 |---|---|---|---|---|
-| `solution_id` | `int` | optional | `1` | The ID of the solution. Normally obtained after creating a new solution. |
+| `solution_id` | `int` | optional | `1` | The ID of the solution. Normally obtained after creating a new solution. This argument can be provided multiple times to select multiple solutions. All other arguments still apply. |
 | `solution_user` | `int` | optional | `1` | The ID of the user who provided the solution. |
 | `solution_exercise` | `int` | optional | `1` | The ID of the exercise which the solution was provided for. |
 | `solution_date` | `int` | optional | `1672946590` | The date and time when the solution attempt was started. Encoded as Unix timestamp. As querring for a specific timestamp, the system queries for all solutions which have the same year, month and date `solution_date`. |

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -45,7 +45,7 @@ Arguments are constructed as dictionaries or JSON objects.
 
 | Argument | Type | Necessity | Example | Description |
 |---|---|---|---|---|
-| `user_id` | `int` | optional | `1` | The ID of the user. Normally obtained after creating a new user. |
+| `user_id` | `int` | optional | `1` | The ID of the user. Normally obtained after creating a new user. This argument can be provided multiple times to select multiple users. All other arguments still apply. |
 | `user_name` | `string` | optional | `John Doe` | The name of the user. Uniqueness is not guaranteed. |
 | `user_mail` | `string` | optional | `john.doe@example.com` | The e-mail address of the user. This is unique for every account. |
 | `user_role` | `int` | optional  | `1` | An integer defining the user role. One of the following values: `1` for super admin, `2` for admin and `3` for regular users. |


### PR DESCRIPTION
This feature allows to select multiple users in one request by specifying multiple IDs in the request. One can do this by simply passing the `user_id` argument multiple times, like this `user_id=2&user_id=3&user_id=4`.

This should resolve issue #196.

**WARNING**: all the other filters still apply. For example: it is not possible to select normal users and admins at the same time, because one can supply only one value for the `user_role` argument (either `User` or `Admin`).